### PR TITLE
[BUGFIX] Prefer Finder->exclude instead Finder-notPath

### DIFF
--- a/src/GitChecker/Finder/RepositoryFinder.php
+++ b/src/GitChecker/Finder/RepositoryFinder.php
@@ -58,7 +58,7 @@ class RepositoryFinder implements \IteratorAggregate
             : [];
         if (!empty($excludeDirs) && is_array($excludeDirs)) {
             foreach ($excludeDirs as $dir) {
-                $this->finder->notPath(strtr($dir, '\\', '/'));
+                $this->finder->exclude(strtr($dir, '\\', '/'));
             }
         }
 


### PR DESCRIPTION
It seems notPath function doesn't really exclude the directories but
filters paths after fetching.